### PR TITLE
Adds Flask-Config to handle configuration files and default_config file

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 import RPi.GPIO as GPIO
 
-class Config():
+class Config(object):
     '''
     Example Config file for use in MediaSync application
     '''

--- a/default_config.py
+++ b/default_config.py
@@ -1,0 +1,31 @@
+class Config():
+    '''
+    Example Config file for use in MediaSync application
+    '''
+
+    # OPTIONAL; location and filename of mediafile for playing (uses OMXPlayer to play). 
+    # If none provided (or incorrect provided), creates fake virtual device
+    VIDEONAME = None
+
+    # OPTIONAL; Enttec serial device for DMX output. 
+    # If none provided (or incorrect provided), creates fake virtual device
+    DMX_DEVICE = "/dev/null"
+
+    # OPTIONAL; BUTTON setup values
+    GPIO_VALUES = {
+        'pin': None,
+        'pull_up_down': None,
+    }
+
+    SCHEDULER_TIME = 0  # OPTIONAL; causes automatic start of sequence via scheduled "virtual" button press
+
+    AUTOREPEAT = False  # OPTIONAL; True causes automatic start and repeat of media sequence. Defaults to False if not defined
+
+    DEFAULT_VALUE = 255  # REQUIRED; the default value of ALL DMX channels at start.
+    DEFAULT_TRANSITION_TIME = 0  # REQUIRED; the default transition time at beginning and end of sequence (bookends LIGHTING_SEQUENCE below)
+
+    # REQUIRED; the DMX channel mapping, i.e. the order of the DMX channels in the LIGHTING_SEQUENCE below
+    CHANNELS = [1]
+
+    # REQUIRED: the sequence of DMX light levels, essentially a playlist of DMX states. Uses CHANNELS (above) for channel order mapping
+    LIGHTING_SEQUENCE = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 omxplayer-wrapper==0.2.5
 RPi.GPIO==0.6.3
+flask==1.0.2


### PR DESCRIPTION
Flask-Config is an extension of the Dict type but allows for loading from files and Config() objects. Using this system allows for the importing of a default config first.

Unfortunately, Flask-Config fails to install solo so this project now has Flask as a requirement.

additionally:
* adds gracefully handling of missing lighting sequence value (OmxDmx)
* adds better logging of when the video is shorter than lighting sequence
* removes config file from input of omxdmx since App is now responsible for pre-screening variables