### PR TITLE
Add loop delay to prevent fast loops

### DIFF
--- a/app.py
+++ b/app.py
@@ -143,7 +143,8 @@ if __name__ == "__main__":
                         dmxChannels=config['CHANNELS'],
                         dmxDefaultVals=config['DEFAULT_VALUE'],
                         defaultTransition_t=config['DEFAULT_TRANSITION_TIME'],
-                        sequence=config['LIGHTING_SEQUENCE'])
+                        sequence=config['LIGHTING_SEQUENCE'],
+                        loopDelay=config['LOOP_DELAY'])
 
     try:
         omxDmxThread.start()

--- a/default_config.py
+++ b/default_config.py
@@ -27,6 +27,11 @@ class Config():
     # if set to '0', scheduler does not run
     SCHEDULER_TIME = 0
 
+    # Delay in seconds during each iteration of the main loop, between checking
+    # for button presses. Prevents the Pi from overheating due to excessive CPU
+    # usage.
+    LOOP_DELAY = 0.1
+
     AUTOREPEAT = False  # True causes automatic start and repeat of media sequence. Defaults to False if not defined
     AUTOREPEAT_TOGGLE = { # Adds a gpio pin to read a toggle switch on startup to enable/disable AUTOREPEAT. NOTE: overrides AUTOREPEAT variable above
         'gpio_pin': None

--- a/omxdmx/omxdmx.py
+++ b/omxdmx/omxdmx.py
@@ -92,13 +92,15 @@ class omxPlayerMock():
 
 
 class OmxDmx(Thread):
-    def __init__(self, buttonEvent, killEvent, mediafile=None, dmxDevice="/dev/null", autorepeat=False, dmxChannels=[1], dmxDefaultVals=255, defaultTransition_t=0, sequence=[]):
+    def __init__(self, buttonEvent, killEvent, mediafile=None, dmxDevice="/dev/null", autorepeat=False, dmxChannels=[1], dmxDefaultVals=255, defaultTransition_t=0, sequence=[], loopDelay=0.1):
         super().__init__()
         self.logger = logging.getLogger("omxdmx")
         self.buttonEvent = buttonEvent
         self.killEvent = killEvent
 
         self.mediafile = mediafile
+
+        self.loopDelay = loopDelay
 
         self.player = self.playerFactory(self.mediafile, self.logger)
 
@@ -153,6 +155,8 @@ class OmxDmx(Thread):
 
         self.logger.debug("Waiting for video")
         while self.running:
+            sleep(self.loopDelay)
+
             if(self.buttonEvent.is_set()):
                 self.playing = True
                 self.logger.debug("Starting Video")


### PR DESCRIPTION
This pull request implements a 0.1 second delay in the main loop of the `OmxDmx` class. Fast loops with no delay can cause the Raspberry Pi to overheat, especially in hot enclosed environments. Overheating may cause the Pi to throttle its CPU or crash entirely. A short loop delay prevents the Raspberry Pi from using more CPU power than is necessary.

The change includes a new configuration variable, set to 0.1 seconds by default, which is processed in the `OmxDmx` class. A delay of 0.1 seconds is usually not noticeable in systems involving a physical button, as it is rare for a button to be pressed for less than 0.1 seconds.